### PR TITLE
Travis: only build pushes to master branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,3 +34,7 @@ cache:
 
 jdk:
   - oraclejdk8
+
+branches:
+    only:
+        - master


### PR DESCRIPTION
The build is too flaky (due to android emulator) to do it twice on PR. PRs are still built once.
