### PR TITLE
Build debug APK before starting emulator

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -33,7 +33,7 @@ dependencies:
 test:
   pre:
   # TODO(dotdoom): consider -PdisablePreDex.
-  - ./gradlew lintDebug testDebugUnitTest --console=plain
+  - ./gradlew lintDebug testDebugUnitTest assembleDebug assembleDebugAndroidTest --console=plain
   - echo no | android create avd --force -n test -t android-24 --abi default/armeabi-v7a
   - emulator -avd test -no-audio -no-window:
       background: true
@@ -44,6 +44,8 @@ test:
   # due to lack of signing keystore at this stage.
   - GRADLE_OPTS=-Xmx256m ./gradlew connectedDebugAndroidTest --console=plain
   post:
+  # Kill running emulator to free up resources for e.g. Release build.
+  - adb -s emulator-5554 emu kill
   # Instrumental tests do not output XML (because they are not junit?). See also:
   # http://stackoverflow.com/questions/2178870/how-to-generate-android-testing-report-in-html-automatically.
   # TODO(dotdoom): figure out how to make instrumental tests and linter results more visible.


### PR DESCRIPTION
There's much more container memory available before Android emulator is
started, so it's better to do memory-heavy work beforehand.